### PR TITLE
Update SelfTestView.swift

### DIFF
--- a/SpellingAppOnline/SelfTestView.swift
+++ b/SpellingAppOnline/SelfTestView.swift
@@ -53,7 +53,8 @@ struct SelfTestView: View {
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .padding()
                     .autocapitalization(.none)
-                    .disableAutocorrection(true)
+                    .keyboardType(.alphabet)
+                    .autocorrectionDisabled()
                     .submitLabel(.next)
                     .onSubmit {
                         nextButton()


### PR DESCRIPTION
Fixes #3 needs to set the keyboard type for the autoCorrectionDisabled to take effect.